### PR TITLE
Fail when clair address is not set

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,8 @@ func main() {
 
 	clairAddr := os.Getenv("CLAIR_ADDR")
 	if clairAddr == "" {
-		clairAddr = "https://clair-staging.optiopay.com"
+		fmt.Printf("Clair address must be provided")
+		os.Exit(1)
 	}
 
 	threshold := 0


### PR DESCRIPTION
There is no reasonable default clair address until somebody provides a public service.