### PR TITLE
fix to allow names with a / in them

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -45,6 +46,7 @@ var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.
 func NewImage(qname, user, password string) (*Image, error) {
 	registry := dockerHub
 	tag := "latest"
+	var nameParts []string
 	var name, port string
 	state := stateInitial
 	start := 0
@@ -90,13 +92,16 @@ func NewImage(qname, user, password string) (*Image, error) {
 				if c == ':' {
 					state = stateTag
 				}
-				name = part
+				nameParts = append(nameParts, part)
 			}
 		}
 	}
 
 	if port != "" {
 		registry = fmt.Sprintf("%s:%s", registry, port)
+	}
+	if name == "" {
+		name = strings.Join(nameParts, "/")
 	}
 
 	registry = fmt.Sprintf("https://%s/v2", registry)

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -27,6 +27,12 @@ func TestNewImage(t *testing.T) {
 			name:     "nginx",
 			tag:      "1b29e1531c",
 		},
+		"regular_extended": {
+			image:    "docker-registry.domain.com/skynetservices/skydns:2.3",
+			registry: "https://docker-registry.domain.com/v2",
+			name:     "skynetservices/skydns",
+			tag:      "2.3",
+		},
 		"no_tag": {
 			image:    "docker-registry.domain.com/nginx",
 			registry: "https://docker-registry.domain.com/v2",


### PR DESCRIPTION
When trying to analyze a image such as myregistry.com/alvinf/image-a, klar fails with "Can't pull fsLayers". It improperly determines that the image name is "image-a" instead of "alvinf/image-a" and this pr grabs the whole image name. Please let me know if this is the right approach thanks!