### PR TITLE
Add optional support for insecure registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Default is `Unknown`.
 
 * `DOCKER_PASSWORD` - Docker registry account password
 
-* `KLAR_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`.
+* `DOCKER_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`. Clair will 
+need to be booted with `-insecure-tls` for this to work.
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Default is `Unknown`.
 
 * `DOCKER_PASSWORD` - Docker registry account password
 
+* `KLAR_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`.
+
 Usage:
 
     CLAIR_ADDR=http://localhost CLAIR_OUTPUT=High CLAIR_THRESHOLD=10 DOCKER_USER=me DOCKER_PASSWORD=secret klar postgres:9.5.1

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -45,7 +45,7 @@ var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.
 // or in any other shorter forms and creates docker image entity without
 // information about layers
 func NewImage(qname, user, password string, insecureTLS bool) (*Image, error) {
-	var tr = &http.Transport{
+	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
 	}
 	client := http.Client{Transport: tr}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,9 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -31,6 +29,7 @@ type Image struct {
 	Token    string
 	user     string
 	password string
+	client   http.Client
 }
 
 // FsLayer represents a layer in docker image
@@ -40,25 +39,16 @@ type FsLayer struct {
 
 const dockerHub = "registry-1.docker.io"
 
-var client http.Client
 var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.*?)"`)
-
-func InitialiseClient() {
-	var insecureTLS = false
-	if envInsecure, err := strconv.ParseBool(os.Getenv("DOCKER_INSECURE")); err == nil {
-		insecureTLS = envInsecure
-	}
-
-	var tr = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
-	}
-	client = http.Client{Transport: tr}
-}
 
 // NewImage parses image name which could be the ful name registry:port/name:tag
 // or in any other shorter forms and creates docker image entity without
 // information about layers
-func NewImage(qname, user, password string) (*Image, error) {
+func NewImage(qname, user, password string, insecureTLS bool) (*Image, error) {
+	var tr = &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
+	}
+	client := http.Client{Transport: tr}
 	registry := dockerHub
 	tag := "latest"
 	var nameParts []string
@@ -126,6 +116,7 @@ func NewImage(qname, user, password string) (*Image, error) {
 		Tag:      tag,
 		user:     user,
 		password: password,
+		client:   client,
 	}, nil
 }
 
@@ -174,7 +165,7 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 		return "", err
 	}
 	req.SetBasicAuth(i.user, i.password)
-	tResp, err := client.Do(req)
+	tResp, err := i.client.Do(req)
 	if err != nil {
 		io.Copy(ioutil.Discard, tResp.Body)
 		return "", err
@@ -213,7 +204,7 @@ func (i *Image) pullReq() (*http.Response, error) {
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.list.v2+json")
 
-	resp, err := client.Do(req)
+	resp, err := i.client.Do(req)
 	if err != nil {
 		fmt.Println("Get error")
 		return nil, err

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -45,7 +45,7 @@ var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.
 
 func InitialiseClient() {
 	var insecureTLS = false
-	if envInsecure, err := strconv.ParseBool(os.Getenv("KLAR_INSECURE")); err == nil {
+	if envInsecure, err := strconv.ParseBool(os.Getenv("DOCKER_INSECURE")); err == nil {
 		insecureTLS = envInsecure
 	}
 

--- a/main.go
+++ b/main.go
@@ -53,6 +53,8 @@ func main() {
 	dockerUser := os.Getenv("DOCKER_USER")
 	dockerPassword := os.Getenv("DOCKER_PASSWORD")
 
+	docker.InitialiseClient()
+
 	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword)
 	if err != nil {
 		fmt.Printf("Can't parse qname: %s", err)

--- a/main.go
+++ b/main.go
@@ -52,10 +52,12 @@ func main() {
 
 	dockerUser := os.Getenv("DOCKER_USER")
 	dockerPassword := os.Getenv("DOCKER_PASSWORD")
+	insecureTLS := false
+	if envInsecure, err := strconv.ParseBool(os.Getenv("DOCKER_INSECURE")); err == nil {
+		insecureTLS = envInsecure
+	}
 
-	docker.InitialiseClient()
-
-	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword)
+	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword, insecureTLS)
 	if err != nil {
 		fmt.Printf("Can't parse qname: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
Allows Klar to access registries with bad SSL certificates (e.g. if you're testing out a private repo setup locally)