### PR TITLE
Request manifest schema version 2

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -194,6 +194,10 @@ func (i *Image) pullReq() (*http.Response, error) {
 	} else {
 		req.Header.Set("Authorization", i.Token)
 	}
+
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.list.v2+json")
+
 	resp, err := client.Do(req)
 	if err != nil {
 		fmt.Println("Get error")


### PR DESCRIPTION
Since earlier this year Google Container Registry (GCR) stores images manifests in manifest schema 2 format[1]. Two of the changes to the schema are that name and tag has been removed. If the client does not indicate support for manifest schema version 2, GCR will assume that the client does not support it and convert the schema to v1. In order to generate valid (schema version 1) JSON GCR sets the values of name and tag to "unused". 

This causes problems for Klar since the response of the manifest request is decoded into the Image struct, effectively setting the name and tag values to "unused".

This PR adds request headers that indicate support for manifest schema version 2. 

See my bug report to GCR for more details.

[1] https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md
[2] https://issuetracker.google.com/issues/37265047