### PR TITLE
Allow insecure/http registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Default is `Unknown`.
 * `DOCKER_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`. Clair will 
 need to be booted with `-insecure-tls` for this to work.
 
+* `REGISTRY_INSECURE` - Allow Klar to access insecure registries (HTTP only). Default is `false`.
+
 * `JSON_OUTPUT` - Output JSON, not plain text. Default is `false`.
 
 Usage:

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -44,7 +44,7 @@ var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.
 // NewImage parses image name which could be the ful name registry:port/name:tag
 // or in any other shorter forms and creates docker image entity without
 // information about layers
-func NewImage(qname, user, password string, insecureTLS bool) (*Image, error) {
+func NewImage(qname, user, password string, insecureTLS, insecureRegistry bool) (*Image, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
 	}
@@ -108,8 +108,12 @@ func NewImage(qname, user, password string, insecureTLS bool) (*Image, error) {
 	if name == "" {
 		name = strings.Join(nameParts, "/")
 	}
+	if insecureRegistry {
+		registry = fmt.Sprintf("http://%s/v2", registry)
+	} else {
+		registry = fmt.Sprintf("https://%s/v2", registry)
+	}
 
-	registry = fmt.Sprintf("https://%s/v2", registry)
 	return &Image{
 		Registry: registry,
 		Name:     name,

--- a/main.go
+++ b/main.go
@@ -64,12 +64,17 @@ func main() {
 		insecureTLS = envInsecure
 	}
 
+	insecureRegistry := false
+	if envInsecureReg, err := strconv.ParseBool(os.Getenv("REGISTRY_INSECURE")); err == nil {
+		insecureRegistry = envInsecureReg
+	}
+
 	useJSONOutput := false
 	if envJSONOutput, err := strconv.ParseBool(os.Getenv("JSON_OUTPUT")); err == nil {
 		useJSONOutput = envJSONOutput
 	}
 
-	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword, insecureTLS)
+	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword, insecureTLS, insecureRegistry)
 	if err != nil {
 		fmt.Printf("Can't parse qname: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
This allows Klar to pull from insecure HTTP-only registries, like one shipped with Openshift.