### PR TITLE
Print errors to stderr only

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -1,6 +1,7 @@
 package clair
 
 import (
+	"os"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -108,7 +109,7 @@ func (c *Clair) Analyse(image *docker.Image) []Vulnerability {
 	image.FsLayers = filterEmptyLayers(image.FsLayers)
 	layerLength := len(image.FsLayers)
 	if layerLength == 0 {
-		fmt.Printf("No need to analyse image %s/%s:%s as there is no non-emtpy layer",
+		fmt.Fprintf(os.Stderr, "No need to analyse image %s/%s:%s as there is no non-emtpy layer",
 			image.Registry, image.Name, image.Tag)
 		return nil
 	}
@@ -118,14 +119,14 @@ func (c *Clair) Analyse(image *docker.Image) []Vulnerability {
 		layer := newLayer(image, i)
 		err := c.pushLayer(layer)
 		if err != nil {
-			fmt.Printf("Push layer %d failed: %s", i, err.Error())
+			fmt.Fprintf(os.Stderr, "Push layer %d failed: %s", i, err.Error())
 			continue
 		}
 	}
 
 	vs, err := c.analyzeLayer(image.FsLayers[0])
 	if err != nil {
-		fmt.Printf("Analyse image %s/%s:%s failed: %s", image.Registry, image.Name, image.Tag, err.Error())
+		fmt.Fprintf(os.Stderr, "Analyse image %s/%s:%s failed: %s", image.Registry, image.Name, image.Tag, err.Error())
 		return nil
 	}
 

--- a/clair/clair.go
+++ b/clair/clair.go
@@ -109,7 +109,7 @@ func (c *Clair) Analyse(image *docker.Image) []Vulnerability {
 	image.FsLayers = filterEmptyLayers(image.FsLayers)
 	layerLength := len(image.FsLayers)
 	if layerLength == 0 {
-		fmt.Fprintf(os.Stderr, "No need to analyse image %s/%s:%s as there is no non-emtpy layer",
+		fmt.Fprintf(os.Stderr, "No need to analyse image %s/%s:%s as there is no non-emtpy layer\n",
 			image.Registry, image.Name, image.Tag)
 		return nil
 	}
@@ -119,14 +119,14 @@ func (c *Clair) Analyse(image *docker.Image) []Vulnerability {
 		layer := newLayer(image, i)
 		err := c.pushLayer(layer)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Push layer %d failed: %s", i, err.Error())
+			fmt.Fprintf(os.Stderr, "Push layer %d failed: %s\n", i, err.Error())
 			continue
 		}
 	}
 
 	vs, err := c.analyzeLayer(image.FsLayers[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Analyse image %s/%s:%s failed: %s", image.Registry, image.Name, image.Tag, err.Error())
+		fmt.Fprintf(os.Stderr, "Analyse image %s/%s:%s failed: %s\n", image.Registry, image.Name, image.Tag, err.Error())
 		return nil
 	}
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"os"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -146,7 +147,7 @@ func (i *Image) Pull() error {
 	}
 	defer resp.Body.Close()
 	if err = json.NewDecoder(resp.Body).Decode(i); err != nil {
-		fmt.Println("Decode error")
+		fmt.Fprintln(os.Stderr, "Decode error")
 		return err
 	}
 	return nil
@@ -165,7 +166,7 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 	url := fmt.Sprintf("%s?service=%s&scope=%s&account=%s", realm, service, scope, i.user)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		fmt.Println("Can't create a request")
+		fmt.Fprintln(os.Stderr, "Can't create a request")
 		return "", err
 	}
 	req.SetBasicAuth(i.user, i.password)
@@ -185,7 +186,7 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 	}
 
 	if err = json.NewDecoder(tResp.Body).Decode(&tokenEnv); err != nil {
-		fmt.Println("Token response decode error")
+		fmt.Fprintln(os.Stderr, "Token response decode error")
 		return "", err
 	}
 	return fmt.Sprintf("Bearer %s", tokenEnv.Token), nil
@@ -195,7 +196,7 @@ func (i *Image) pullReq() (*http.Response, error) {
 	url := fmt.Sprintf("%s/%s/manifests/%s", i.Registry, i.Name, i.Tag)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		fmt.Println("Can't create a request")
+		fmt.Fprintln(os.Stderr, "Can't create a request")
 		return nil, err
 	}
 	if i.Token == "" {
@@ -210,7 +211,7 @@ func (i *Image) pullReq() (*http.Response, error) {
 
 	resp, err := i.client.Do(req)
 	if err != nil {
-		fmt.Println("Get error")
+		fmt.Fprintln(os.Stderr, "Get error")
 		return nil, err
 	}
 	return resp, nil
@@ -219,17 +220,17 @@ func (i *Image) pullReq() (*http.Response, error) {
 func dumpRequest(r *http.Request) {
 	dump, err := httputil.DumpRequest(r, true)
 	if err != nil {
-		fmt.Printf("Can't dump HTTP request %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Can't dump HTTP request %s\n", err.Error())
 	} else {
-		fmt.Printf("request_dump: %s\n", string(dump[:]))
+		fmt.Fprintf(os.Stderr, "request_dump: %s\n", string(dump[:]))
 	}
 }
 
 func dumpResponse(r *http.Response) {
 	dump, err := httputil.DumpResponse(r, true)
 	if err != nil {
-		fmt.Printf("Can't dump HTTP reqsponse %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Can't dump HTTP reqsponse %s\n", err.Error())
 	} else {
-		fmt.Printf("response_dump: %s\n", string(dump[:]))
+		fmt.Fprintf(os.Stderr, "response_dump: %s\n", string(dump[:]))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -21,13 +21,13 @@ var store = make(map[string][]clair.Vulnerability)
 
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Fprintf(os.Stderr, "Image name must be provided")
+		fmt.Fprintf(os.Stderr, "Image name must be provided\n")
 		os.Exit(1)
 	}
 
 	clairAddr := os.Getenv("CLAIR_ADDR")
 	if clairAddr == "" {
-		fmt.Fprintf(os.Stderr, "Clair address must be provided")
+		fmt.Fprintf(os.Stderr, "Clair address must be provided\n")
 		os.Exit(1)
 	}
 
@@ -45,7 +45,7 @@ func main() {
 		}
 
 		if !correct {
-			fmt.Fprintf(os.Stderr, "Clair output level %s is not supported, only support %v", outputEnv, priorities)
+			fmt.Fprintf(os.Stderr, "Clair output level %s is not supported, only support %v\n", outputEnv, priorities)
 			os.Exit(1)
 		}
 	}
@@ -76,20 +76,20 @@ func main() {
 
 	image, err := docker.NewImage(os.Args[1], dockerUser, dockerPassword, insecureTLS, insecureRegistry)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't parse qname: %s", err)
+		fmt.Fprintf(os.Stderr, "Can't parse qname: %s\n", err)
 		os.Exit(1)
 	}
 
 	err = image.Pull()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't pull image: %s", err)
+		fmt.Fprintf(os.Stderr, "Can't pull image: %s\n", err)
 		os.Exit(1)
 	}
 
 	var output = jsonOutput{}
 
 	if len(image.FsLayers) == 0 {
-		fmt.Fprintf(os.Stderr, "Can't pull fsLayers")
+		fmt.Fprintf(os.Stderr, "Can't pull fsLayers\n")
 		os.Exit(1)
 	} else {
 		if useJSONOutput {

--- a/main.go
+++ b/main.go
@@ -109,14 +109,14 @@ func main() {
 		enc := json.NewEncoder(os.Stdout)
 		enc.Encode(output)
 	} else {
-		fmt.Fprintf(os.Stderr, "Found %d vulnerabilities \n", len(vs))
+		fmt.Printf("Found %d vulnerabilities \n", len(vs))
 		iteratePriorities(clairOutput, func(sev string) {
 			for _, v := range store[sev] {
-				fmt.Fprintf(os.Stderr, "%s: [%s] \n%s\n%s\n", v.Name, v.Severity, v.Description, v.Link)
-				fmt.Fprintln(os.Stderr, "-----------------------------------------")
+				fmt.Printf("%s: [%s] \n%s\n%s\n", v.Name, v.Severity, v.Description, v.Link)
+				fmt.Println("-----------------------------------------")
 			}
 		})
-		iteratePriorities(priorities[0], func(sev string) { fmt.Fprintf(os.Stderr, "%s: %d\n", sev, len(store[sev])) })
+		iteratePriorities(priorities[0], func(sev string) { fmt.Printf("%s: %d\n", sev, len(store[sev])) })
 	}
 
 	if highSevNumber > threshold {


### PR DESCRIPTION
It's a good practice to send errors to stderr only. That way, json output won't be messed up when something goes wrong, like a layer that failed to be push()ed.
Also, merged and extended #31 