### PR TITLE
Speed up image name parsing

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -85,7 +85,6 @@ func NewImage(qname, user, password string, insecureTLS, insecureRegistry bool) 
 			start = i + 1
 			switch state {
 			case stateInitial:
-				//addrs, err := net.LookupHost(part)
 				if part == "localhost" || strings.Contains(part, ".") {
 					// it's registry, let's check what's next =port of image name
 					registry = part

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -86,9 +85,16 @@ func NewImage(qname, user, password string, insecureTLS, insecureRegistry bool) 
 			start = i + 1
 			switch state {
 			case stateInitial:
-				addrs, err := net.LookupHost(part)
-				// not a hostname?
-				if err != nil || len(addrs) == 0 {
+				//addrs, err := net.LookupHost(part)
+				if part == "localhost" || strings.Contains(part, ".") {
+					// it's registry, let's check what's next =port of image name
+					registry = part
+					if c == ':' {
+						state = statePort
+					} else {
+						state = stateName
+					}
+				} else {
 					// it's an image name, if separator is /
 					// next part is also part of the name
 					// othrewise it's an offcial image
@@ -99,14 +105,6 @@ func NewImage(qname, user, password string, insecureTLS, insecureRegistry bool) 
 					} else {
 						state = stateTag
 						name = fmt.Sprintf("library/%s", part)
-					}
-				} else {
-					// it's registry, let's check what's next =port of image name
-					registry = part
-					if c == ':' {
-						state = statePort
-					} else {
-						state = stateName
 					}
 				}
 			case stateTag:

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -64,6 +64,18 @@ func TestNewImage(t *testing.T) {
 			name:     "library/postgres",
 			tag:      "sha256:f6a2b81d981ace74aeafb2ed2982d52984d82958bfe836b82cbe4bf1ba440999",
 		},
+		"localhost_no_tag": {
+			image:    "localhost/nginx",
+			registry: "https://localhost/v2",
+			name:     "nginx",
+			tag:      "latest",
+		},
+		"localhost_tag_with_port": {
+			image:    "localhost:8080/nginx:xxx",
+			registry: "https://localhost:8080/v2",
+			name:     "nginx",
+			tag:      "xxx",
+		},
 	}
 	for name, tc := range tcs {
 		image, err := NewImage(tc.image, "", "", false, false)


### PR DESCRIPTION
This fix removes hostname resolution from image name parsing function.
It decreases time of tests execution from 15 secs to 0.02 on my machine.
The drawback is that we can't use short hostname (except localhost) as a
registry hostname. However docker client itself doesn't support such
hostnames, so it's a safe assumption for Klar.
https://github.com/moby/moby/blob/master/vendor/github.com/docker/distribution/reference/normalize.go#L64