### PR TITLE
update base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine
 
 ENV DOMAIN=skydns.local
 ENV RELEASE 0.1


### PR DESCRIPTION
Fix #51: The klar image can not run as error `exec user process caused "no such file or directory"`.