### PR TITLE
Updated Readme to make static build possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Usage:
 
 ## Dockerized version
 
-Klar can be dockerized. Go to `$GOPATH/src/github.com/optiopay/klar` and build Klar in project root:
+Klar can be dockerized. Go to `$GOPATH/src/github.com/optiopay/klar` and build Klar in project root. If you are on Linux:
 
-    go build .
+    CGO_ENABLED=0 go build -a -installsuffix cgo .
 
 If you are on Mac don't forget to build it for Linux:
 


### PR DESCRIPTION
docker images built on linux will not work otherwise, because they are dynamically linked. The scratch image does not provide a libc.

See https://blog.codeship.com/building-minimal-docker-containers-for-go-applications/ for more info