### PR TITLE
Full support of registry v2 and Clair v2

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -267,7 +267,7 @@ func (i *Image) pullReq() (*http.Response, error) {
 	}
 
 	// Prefer manifest schema v2
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 
 	resp, err := i.client.Do(req)
 	if err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/optiopay/klar/utils"
 )
 
 const (
@@ -95,7 +98,10 @@ func NewImage(qname, user, password string, insecureTLS, insecureRegistry bool) 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
 	}
-	client := http.Client{Transport: tr}
+	client := http.Client{
+		Transport: tr,
+		Timeout:   time.Minute,
+	}
 	registry := dockerHub
 	tag := "latest"
 	var nameParts, tagParts []string
@@ -292,10 +298,12 @@ func (i *Image) pullReq() (*http.Response, error) {
 
 	// Prefer manifest schema v2
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	utils.DumpRequest(req)
 	resp, err := i.client.Do(req)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Get error")
 		return nil, err
 	}
+	utils.DumpResponse(resp)
 	return resp, nil
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/optiopay/klar/clair"
 	"github.com/optiopay/klar/docker"
+	"github.com/optiopay/klar/utils"
 )
 
 type jsonOutput struct {
@@ -23,6 +24,10 @@ func main() {
 	if len(os.Args) != 2 {
 		fmt.Fprintf(os.Stderr, "Image name must be provided\n")
 		os.Exit(1)
+	}
+
+	if os.Getenv("KLAR_TRACE") != "" {
+		utils.Trace = true
 	}
 
 	clairAddr := os.Getenv("CLAIR_ADDR")

--- a/utils/http.go
+++ b/utils/http.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+)
+
+func DumpRequest(r *http.Request) {
+	dump, err := httputil.DumpRequest(r, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't dump HTTP request %s\n", err.Error())
+	} else {
+		fmt.Fprintf(os.Stderr, "request_dump: %s\n", string(dump[:]))
+	}
+}
+
+func DumpResponse(r *http.Response) {
+	dump, err := httputil.DumpResponse(r, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't dump HTTP reqsponse %s\n", err.Error())
+	} else {
+		fmt.Fprintf(os.Stderr, "response_dump: %s\n", string(dump[:]))
+	}
+}

--- a/utils/http.go
+++ b/utils/http.go
@@ -7,20 +7,28 @@ import (
 	"os"
 )
 
+var Trace bool
+
 func DumpRequest(r *http.Request) {
+	if !Trace {
+		return
+	}
 	dump, err := httputil.DumpRequest(r, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't dump HTTP request %s\n", err.Error())
 	} else {
-		fmt.Fprintf(os.Stderr, "request_dump: %s\n", string(dump[:]))
+		fmt.Fprintf(os.Stderr, "----> HTTP REQUEST:\n%s\n", string(dump[:]))
 	}
 }
 
 func DumpResponse(r *http.Response) {
+	if !Trace {
+		return
+	}
 	dump, err := httputil.DumpResponse(r, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't dump HTTP reqsponse %s\n", err.Error())
 	} else {
-		fmt.Fprintf(os.Stderr, "response_dump: %s\n", string(dump[:]))
+		fmt.Fprintf(os.Stderr, "<---- HTTP RESPONSE:\n%s\n", string(dump[:]))
 	}
 }


### PR DESCRIPTION
* Remove manifest list from accepted types 
* Registry v2 returns layers in the reverse order, support both orders
* Add tracing support