### PR TITLE
Add warning explaining errror 404

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -193,6 +193,9 @@ func (c *Clair) pushLayer(layer *layer) error {
 		return fmt.Errorf("Can't read clair response : %s", err)
 	}
 	if response.StatusCode != http.StatusCreated {
+		if response.StatusCode == http.StatusNotFound {
+			fmt.Fprintf(os.Stderr, "Can't find Clair v1.x or 2.x, probably you use unsupported version - v3.x or custom build.\n")
+		}
 		var lerr layerError
 		err = json.Unmarshal(body, &lerr)
 		if err != nil {


### PR DESCRIPTION
Clair V3 dropped support of API which was used in v1 & V2. Klar doesn't
support yet the new API, but some users already use it. This PR tries to minimize a user confusion by
providing an explanation why error 404  happened.