### PR TITLE
Set docker registry address as ENV var 

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
 	"github.com/optiopay/klar/utils"
 )
 
@@ -93,9 +92,9 @@ type Config struct {
 	Password         string
 	InsecureTLS      bool
 	InsecureRegistry bool
-}
+	RegistryAddr	 string
 
-const dockerHub = "registry-1.docker.io"
+}
 
 var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.*?)"`)
 
@@ -110,7 +109,7 @@ func NewImage(conf *Config) (*Image, error) {
 		Transport: tr,
 		Timeout:   time.Minute,
 	}
-	registry := dockerHub
+	registry := conf.RegistryAddr
 	tag := "latest"
 	var nameParts, tagParts []string
 	var name, port string

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -92,8 +92,7 @@ type Config struct {
 	Password         string
 	InsecureTLS      bool
 	InsecureRegistry bool
-	RegistryAddr	 string
-
+	RegistryAddr     string
 }
 
 var tokenRe = regexp.MustCompile(`Bearer realm="(.*?)",service="(.*?)",scope="(.*?)"`)

--- a/klar.go
+++ b/klar.go
@@ -109,6 +109,5 @@ func newConfig(args []string) (*config, error) {
 			InsecureRegistry: parseBoolOption(optionRegistryInsecure),
 			RegistryAddr:     registryAddr,
 		},
-
 	}, nil
 }

--- a/klar.go
+++ b/klar.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
 	"github.com/optiopay/klar/clair"
 	"github.com/optiopay/klar/docker"
 	"github.com/optiopay/klar/utils"
@@ -17,6 +16,7 @@ const (
 	optionKlarTrace        = "KLAR_TRACE"
 	optionClairThreshold   = "CLAIR_THRESHOLD"
 	optionJSONOutput       = "JSON_OUTPUT"
+	optionDockerRegistry   = "DOCKER_REGISTRY"
 	optionDockerUser       = "DOCKER_USER"
 	optionDockerPassword   = "DOCKER_PASSWORD"
 	optionDockerInsecure   = "DOCKER_INSECURE"
@@ -82,6 +82,11 @@ func newConfig(args []string) (*config, error) {
 		return nil, fmt.Errorf("Clair address must be provided\n")
 	}
 
+	registryAddr := os.Getenv(optionDockerRegistry)
+	if registryAddr == "" {
+		return nil, fmt.Errorf("Docker registry must be provided\n")
+	}
+
 	if os.Getenv(optionKlarTrace) != "" {
 		utils.Trace = true
 	}
@@ -90,6 +95,7 @@ func newConfig(args []string) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &config{
 		ClairAddr:   clairAddr,
 		ClairOutput: clairOutput,
@@ -101,6 +107,8 @@ func newConfig(args []string) (*config, error) {
 			Password:         os.Getenv(optionDockerPassword),
 			InsecureTLS:      parseBoolOption(optionDockerInsecure),
 			InsecureRegistry: parseBoolOption(optionRegistryInsecure),
+			RegistryAddr:     registryAddr,
 		},
+
 	}, nil
 }

--- a/klar.go
+++ b/klar.go
@@ -16,7 +16,7 @@ const (
 	optionKlarTrace        = "KLAR_TRACE"
 	optionClairThreshold   = "CLAIR_THRESHOLD"
 	optionJSONOutput       = "JSON_OUTPUT"
-	optionDockerRegistry   = "DOCKER_REGISTRY"
+	optionRegistryAddr     = "REGISTRY_ADDR"
 	optionDockerUser       = "DOCKER_USER"
 	optionDockerPassword   = "DOCKER_PASSWORD"
 	optionDockerInsecure   = "DOCKER_INSECURE"
@@ -82,7 +82,7 @@ func newConfig(args []string) (*config, error) {
 		return nil, fmt.Errorf("Clair address must be provided\n")
 	}
 
-	registryAddr := os.Getenv(optionDockerRegistry)
+	registryAddr := os.Getenv(optionRegistryAddr)
 	if registryAddr == "" {
 		return nil, fmt.Errorf("Docker registry must be provided\n")
 	}


### PR DESCRIPTION
Would it be possible to specify the docker registry address as ENV var - rather than hardcoding `const dockerHub = "registry-1.docker.io"`

We want to scan images in an internally hosted registry.