### PR TITLE
Longer timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.8-alpine
 
-RUN apk --update add git;
-RUN go get -d github.com/optiopay/klar
-RUN go build ./src/github.com/optiopay/klar
+COPY . .
 
-FROM alpine:3.6
-
-RUN apk add --no-cache ca-certificates
-COPY --from=builder /go/klar /klar
+RUN apk --update add git && \
+  apk add --no-cache ca-certificates && \
+  mv vendor/* src && \
+  go build -o klar . && \
+  cp klar /
 
 ENTRYPOINT ["/klar"]

--- a/clair/api.go
+++ b/clair/api.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/coreos/clair/api/v3/clairpb"
-	"github.com/optiopay/klar/docker"
-	"github.com/optiopay/klar/utils"
+	"../docker"
+	"../utils"
 	"google.golang.org/grpc"
 )
 
@@ -43,7 +43,7 @@ func newAPIV1(url string) *apiV1 {
 	return &apiV1{
 		url: url,
 		client: http.Client{
-			Timeout: time.Minute,
+			Timeout: time.Hour,
 		},
 	}
 }

--- a/clair/clair.go
+++ b/clair/clair.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/optiopay/klar/docker"
+	"../docker"
 )
 
 const EMPTY_LAYER_BLOB_SUM = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"

--- a/clair/clair_test.go
+++ b/clair/clair_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/coreos/clair/api/v3/clairpb"
-	"github.com/optiopay/klar/docker"
+	"../docker"
 	"google.golang.org/grpc"
 )
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/optiopay/klar/utils"
+	"../utils"
 )
 
 const (
@@ -108,7 +108,7 @@ func NewImage(conf *Config) (*Image, error) {
 	}
 	client := http.Client{
 		Transport: tr,
-		Timeout:   time.Minute,
+		Timeout:   time.Hour,
 	}
 	registry := dockerHub
 	tag := "latest"

--- a/klar.go
+++ b/klar.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/optiopay/klar/clair"
-	"github.com/optiopay/klar/docker"
-	"github.com/optiopay/klar/utils"
+	"./clair"
+	"./docker"
+	"./utils"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/optiopay/klar/clair"
-	"github.com/optiopay/klar/docker"
+	"./clair"
+	"./docker"
 )
 
 var store = make(map[string][]*clair.Vulnerability)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -332,5 +332,5 @@
 			"revisionTime": "2017-11-28T22:41:43Z"
 		}
 	],
-	"rootPath": "github.com/optiopay/klar"
+	"rootPath": "github.com/agius/klar"
 }


### PR DESCRIPTION
Oh, whoops, didn't mean to PR to the main repo. I don't know go, have no clue what I'm doing, but I keep getting timeout errors when trying to push a layer to Clair. A timeout of [one minute](https://github.com/optiopay/klar/blob/master/clair/api.go#L46) seems a little low, and there appears to be no way to configure it. 

```
Failed to analyze using API v1: push image https://<redacted>.ecr.us-east-1.amazonaws.com/v2/my-repo:123abc456def789 to Clair failed: can't push layer to Clair: Post http://clair:6060/v1/layers: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

I'm experimenting on my branch to see if increasing the timeout (or setting to `0` for "no timeouts plz") actually fixes my issue, or if it's a red herring. If this fixes my issue I'll figure out how to make the timeout configurable, update the PR and ping for a code review.