### PR TITLE
Fixes for release 2.0.2

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -305,7 +305,7 @@ func (i *Image) pullReq() (*http.Response, error) {
 	}
 
 	// Prefer manifest schema v2
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.v1+prettyjws")
 	utils.DumpRequest(req)
 	resp, err := i.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
* Can't pull fsLayers with public GCR image #83