### PR TITLE
Remove non JSON logging when JSON variable is true

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to analyze using API v%d: %s\n", ver, err)
 		} else {
-			if conf.JSONOutput == false {
+			if !conf.JSONOutput {
 				fmt.Printf("Got results from Clair API v%d\n", ver)
 			}
 			break


### PR DESCRIPTION
When JSON_OUTPUT var is true, its nice to only output json for a successful scan so I can be parsed or piped to jq