### PR TITLE
Add support for existing registry tokens per optiopay/klar#18

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Default is `Unknown`.
 
 * `DOCKER_PASSWORD` - Docker registry account password.
 
-* `DOCKER_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`. Clair will 
+* `DOCKER_TOKEN` - Docker registry account token. (Can be used in place of `DOCKER_USER` and `DOCKER_PASSWORD`)
+
+* `DOCKER_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`. Clair will
 need to be booted with `-insecure-tls` for this to work.
 
 * `REGISTRY_INSECURE` - Allow Klar to access insecure registries (HTTP only). Default is `false`.

--- a/klar.go
+++ b/klar.go
@@ -19,6 +19,7 @@ const (
 	optionJSONOutput       = "JSON_OUTPUT"
 	optionDockerUser       = "DOCKER_USER"
 	optionDockerPassword   = "DOCKER_PASSWORD"
+	optionDockerToken      = "DOCKER_TOKEN"
 	optionDockerInsecure   = "DOCKER_INSECURE"
 	optionRegistryInsecure = "REGISTRY_INSECURE"
 )
@@ -99,6 +100,7 @@ func newConfig(args []string) (*config, error) {
 			ImageName:        args[1],
 			User:             os.Getenv(optionDockerUser),
 			Password:         os.Getenv(optionDockerPassword),
+			Token:            os.Getenv(optionDockerToken),
 			InsecureTLS:      parseBoolOption(optionDockerInsecure),
 			InsecureRegistry: parseBoolOption(optionRegistryInsecure),
 		},


### PR DESCRIPTION
This allows for specifying a token and still pulling from the unauthenticated dockerhub, the same behavior the DOCKER_USER and DOCKER_PASSWORD allows.