### PR TITLE
Fix edgecase if token is specified and not needed

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -214,8 +214,22 @@ func (i *Image) Pull() error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
+		// try one more time by clearing the token to request it
+		if resp.StatusCode == http.StatusUnauthorized {
+			i.Token, err = i.requestToken(resp)
+			io.Copy(ioutil.Discard, resp.Body)
+			if err != nil {
+				return err
+			}
+			// try again
+			resp, err = i.pullReq()
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+		}
 	}
-	defer resp.Body.Close()
 	return parseImageResponse(resp, i)
 }
 
@@ -310,7 +324,6 @@ func (i *Image) pullReq() (*http.Response, error) {
 		}
 	} else {
 		req.Header.Set("Authorization", i.Token)
-		i.Token = ""
 	}
 
 	// Prefer manifest schema v2


### PR DESCRIPTION
If token is specified (for a private registry, for example), but not correct (i.e. the image is for the public docker registry), but we can obtain a proper token (like if the image is in a public docker registry), we should ignore the passed in token and get the proper token.