### PR TITLE
Add support to configure docker/clair timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Default is `Unknown`.
 
 * `CLAIR_THRESHOLD` - how many outputted vulnerabilities Klar can tolerate before returning `1`. Default is `0`.
 
+* `CLAIR_TIMEOUT` - timeout in minutes before Klar cancels the image scanning. Default is `1`
+
 * `DOCKER_USER` - Docker registry account name.
 
 * `DOCKER_PASSWORD` - Docker registry account password.
@@ -42,6 +44,8 @@ Default is `Unknown`.
 
 * `DOCKER_INSECURE` - Allow Klar to access registries with bad SSL certificates. Default is `false`. Clair will
 need to be booted with `-insecure-tls` for this to work.
+
+* `DOCKER_TIMEOUT` - timeout in minutes when trying to fetch layers from a docker registry
 
 * `REGISTRY_INSECURE` - Allow Klar to access insecure registries (HTTP only). Default is `false`.
 

--- a/clair/api.go
+++ b/clair/api.go
@@ -26,14 +26,14 @@ type apiV3 struct {
 	client clairpb.AncestryServiceClient
 }
 
-func newAPI(url string, version int) (API, error) {
+func newAPI(url string, version int, timeout time.Duration) (API, error) {
 	if version < 3 {
-		return newAPIV1(url), nil
+		return newAPIV1(url, timeout), nil
 	}
 	return newAPIV3(url)
 }
 
-func newAPIV1(url string) *apiV1 {
+func newAPIV1(url string, timeout time.Duration) *apiV1 {
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		url = fmt.Sprintf("http://%s", url)
 	}
@@ -43,7 +43,7 @@ func newAPIV1(url string) *apiV1 {
 	return &apiV1{
 		url: url,
 		client: http.Client{
-			Timeout: time.Minute,
+			Timeout: timeout,
 		},
 	}
 }

--- a/clair/api_test.go
+++ b/clair/api_test.go
@@ -1,6 +1,9 @@
 package clair
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNewAPIV1(t *testing.T) {
 	cases := []struct {
@@ -29,7 +32,7 @@ func TestNewAPIV1(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		api := newAPIV1(tc.url)
+		api := newAPIV1(tc.url, time.Minute)
 		if api.url != tc.expected {
 			t.Errorf("expected %s got %s", api.url, tc.expected)
 		}

--- a/clair/clair.go
+++ b/clair/clair.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/optiopay/klar/docker"
 )
@@ -70,8 +71,8 @@ type layerEnvelope struct {
 
 // NewClair construct Clair entity using potentially incomplete server URL
 // If protocol is missing HTTP will be used. If port is missing 6060 will be used
-func NewClair(url string, version int) Clair {
-	api, err := newAPI(url, version)
+func NewClair(url string, version int, timeout time.Duration) Clair {
+	api, err := newAPI(url, version, timeout)
 	if err != nil {
 		panic(fmt.Sprintf("cant't create API client version %d %s: %s", version, url, err))
 	}

--- a/clair/clair_test.go
+++ b/clair/clair_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/clair/api/v3/clairpb"
 	"github.com/optiopay/klar/docker"
@@ -89,7 +90,7 @@ func TestAnalyseV1(t *testing.T) {
 	ts := httptest.NewServer(clairServerhandler(t))
 	defer ts.Close()
 
-	c := NewClair(ts.URL, 1)
+	c := NewClair(ts.URL, 1, time.Minute)
 	vs, err := c.Analyse(dockerImage)
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +153,7 @@ func (s *gServer) GetAncestry(ctx context.Context, in *clairpb.GetAncestryReques
 }
 
 func TestAnalyseV3(t *testing.T) {
-	c := NewClair(gAddr, 3)
+	c := NewClair(gAddr, 3, time.Minute)
 	vs, err := c.Analyse(dockerImage)
 	if err != nil {
 		t.Fatal(err)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -94,6 +94,7 @@ type Config struct {
 	Token            string
 	InsecureTLS      bool
 	InsecureRegistry bool
+	Timeout          time.Duration
 }
 
 const dockerHub = "registry-1.docker.io"
@@ -109,7 +110,7 @@ func NewImage(conf *Config) (*Image, error) {
 	}
 	client := http.Client{
 		Transport: tr,
-		Timeout:   time.Minute,
+		Timeout:   conf.Timeout,
 	}
 	registry := dockerHub
 	tag := "latest"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,9 @@ func main() {
 		fail("Invalid options: %s", err)
 	}
 
+	fmt.Fprintf(os.Stderr, "clair timeout %s\n", conf.ClairTimeout)
+	fmt.Fprintf(os.Stderr, "docker timeout: %s\n", conf.DockerConfig.Timeout)
+
 	image, err := docker.NewImage(&conf.DockerConfig)
 	if err != nil {
 		fail("Can't parse qname: %s", err)
@@ -52,7 +55,7 @@ func main() {
 
 	var vs []*clair.Vulnerability
 	for _, ver := range []int{1, 3} {
-		c := clair.NewClair(conf.ClairAddr, ver)
+		c := clair.NewClair(conf.ClairAddr, ver, conf.ClairTimeout)
 		vs, err = c.Analyse(image)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to analyze using API v%d: %s\n", ver, err)


### PR DESCRIPTION
This pull request adds support to configure clair (API v1) and docker timeouts using environment variables. Fixes #88