### PR TITLE
Use whitelist for specific image instead of base.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/optiopay/klar/clair"
 	"github.com/optiopay/klar/docker"
@@ -89,7 +88,7 @@ func main() {
 
 	//apply whitelist
 	numVulnerabilites := len(vs)
-	vs = filterWhitelist(whitelist, vs)
+	vs = filterWhitelist(whitelist, vs, image.Name)
 	numVulnerabilitiesAfterWhitelist := len(vs)
 
 	groupBySeverity(vs)
@@ -160,7 +159,7 @@ func vulnsBy(sev string, store map[string][]*clair.Vulnerability) []*clair.Vulne
 }
 
 //Filter out whitelisted vulnerabilites
-func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerability) []*clair.Vulnerability {
+func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerability, imageName string) []*clair.Vulnerability {
 	generalWhitelist := whitelist.General
 	imageWhitelist := whitelist.Images
 
@@ -168,8 +167,6 @@ func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerabil
 
 	for _, v := range vs {
 		if _, exists := generalWhitelist[v.Name]; !exists {
-			//vulnerability is not in the general whitelist, so get the image name by removing ":version" from the value returned via the Clair API
-			imageName := strings.Split(v.NamespaceName, ":")[0]
 			if _, exists := imageWhitelist[imageName][v.Name]; !exists {
 				//vulnerability is not in the image whitelist, so add it to the list to return
 				filteredVs = append(filteredVs, v)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/optiopay/klar/clair"
+)
+
+func TestFilterWhitelist(t *testing.T) {
+	image := "fluent/fluent-bit"
+	whitelist := &vulnerabilitiesWhitelist{
+		map[string]bool{"CVE-3": true},
+		map[string]map[string]bool{image: {"CVE-4": true}},
+	}
+
+	vs := make([]*clair.Vulnerability, 5)
+	for i := range vs {
+		vs[i] = mockVulnerability(fmt.Sprintf("CVE-%d", i))
+	}
+
+	expected := make([]*clair.Vulnerability, 3)
+	for i := range expected {
+		expected[i] = mockVulnerability(fmt.Sprintf("CVE-%d", i))
+	}
+
+	filtered := filterWhitelist(whitelist, vs, image)
+	if !reflect.DeepEqual(filtered, expected) {
+		t.Fatalf("Actual filtered vulnerabilities %s did not match expected ones %s.", filtered, expected)
+	}
+
+}
+func mockVulnerability(name string) *clair.Vulnerability {
+	return &clair.Vulnerability{name, "", "", "", "", nil, "", nil, "", ""}
+}

--- a/whitelist-example.yaml
+++ b/whitelist-example.yaml
@@ -6,3 +6,6 @@ images:
     - RHSA-2018:0805
   alpine:
     - CVE-2017-9671
+  fluent/fluent-bit:
+    - CVE-2017-14062
+    - CVE-2018-6485


### PR DESCRIPTION
* e.g. "fluent/fluent-bit" instead of "debian"
* fixes #104 

If you want to avoid a breaking change to the whitelist semantics, we could also introduce a third section (something like `specificImages`), but I am not sure if this is necessary.