### PR TITLE
Add support for ignoring unfixed vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk --update add git;
 RUN go get -d github.com/optiopay/klar
 RUN go build ./src/github.com/optiopay/klar
 
-FROM alpine:3.6
+FROM alpine:3.8
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/klar /klar

--- a/klar.go
+++ b/klar.go
@@ -41,6 +41,7 @@ const (
 	optionDockerInsecure   = "DOCKER_INSECURE"
 	optionRegistryInsecure = "REGISTRY_INSECURE"
 	optionWhiteListFile    = "WHITELIST_FILE"
+	optionIgnoreUnfixed    = "IGNORE_UNFIXED"
 )
 
 var priorities = []string{"Unknown", "Negligible", "Low", "Medium", "High", "Critical", "Defcon1"}
@@ -96,6 +97,7 @@ type config struct {
 	ClairTimeout  time.Duration
 	DockerConfig  docker.Config
 	WhiteListFile string
+	IgnoreUnfixed bool
 }
 
 func newConfig(args []string) (*config, error) {
@@ -128,6 +130,7 @@ func newConfig(args []string) (*config, error) {
 		ClairOutput:   clairOutput,
 		Threshold:     parseIntOption(optionClairThreshold),
 		JSONOutput:    parseBoolOption(optionJSONOutput),
+		IgnoreUnfixed: parseBoolOption(optionIgnoreUnfixed),
 		ClairTimeout:  time.Duration(clairTimeout) * time.Minute,
 		WhiteListFile: os.Getenv(optionWhiteListFile),
 		DockerConfig: docker.Config{

--- a/main.go
+++ b/main.go
@@ -96,7 +96,16 @@ func main() {
 
 	if conf.JSONOutput {
 		iteratePriorities(conf.ClairOutput, func(sev string) {
-			vsNumber += len(store[sev])
+			if conf.IgnoreUnfixed {
+				// need to iterate over store[sev]
+				for _, v := range store[sev] {
+					if v.FixedBy != "" {
+						vsNumber++
+					}
+				}
+			} else {
+				vsNumber += len(store[sev])
+			}
 			output.Vulnerabilities[sev] = store[sev]
 		})
 		enc := json.NewEncoder(os.Stdout)
@@ -111,10 +120,17 @@ func main() {
 		fmt.Printf("\n")
 
 		iteratePriorities(conf.ClairOutput, func(sev string) {
-			vsNumber += len(store[sev])
 			for _, v := range store[sev] {
-				fmt.Printf("%s: [%s] \nFound in: %s [%s]\nFixed By: %s\n%s\n%s\n", v.Name, v.Severity, v.FeatureName, v.FeatureVersion, v.FixedBy, v.Description, v.Link)
+				fmt.Printf("%s: [%s] \nFound in: %s [%s]\nFixed By: %s\n%s\n%s\n", v.Name, v.Severity, v.FeatureName, 
+v.FeatureVersion, v.FixedBy, v.Description, v.Link)
 				fmt.Println("-----------------------------------------")
+				if conf.IgnoreUnfixed {
+					if v.FixedBy != "" {
+						vsNumber++
+					}
+				} else {
+					vsNumber++
+				}
 			}
 		})
 
@@ -176,3 +192,4 @@ func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerabil
 
 	return filteredVs
 }
+


### PR DESCRIPTION
Adds the option not to count unfixed vulnerabilities when calculating klar's exit code.
Fixes [#109](https://github.com/optiopay/klar/issues/109).