### PR TITLE
Modify exit status, to distinguish between runtime errors and vulnerabilities being present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make sure your Go binary folder is in your `PATH` (e.g. `export PATH=$PATH:/usr/
 
 ## Usage
 
-Klar process returns `0` if the number of detected high severity vulnerabilities in an image is less than or equal to a threshold (see below), otherwise it returns `1`.
+Klar process returns if `0` if the number of detected high severity vulnerabilities in an image is less than or equal to a threshold (see below) and `1` if an error ahs prevented the image from being analyzed. Otherwise it returns `2`, indicating vulnerabilities were found.
 
 Klar can be configured via the following environment variables:
 
@@ -32,7 +32,7 @@ Klar can be configured via the following environment variables:
 will be outputted. Supported levels are `Unknown`, `Negligible`, `Low`, `Medium`, `High`, `Critical`, `Defcon1`.
 Default is `Unknown`.
 
-* `CLAIR_THRESHOLD` - how many outputted vulnerabilities Klar can tolerate before returning `1`. Default is `0`.
+* `CLAIR_THRESHOLD` - how many outputted vulnerabilities Klar can tolerate before returning `2`. Default is `0`.
 
 * `CLAIR_TIMEOUT` - timeout in minutes before Klar cancels the image scanning. Default is `1`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make sure your Go binary folder is in your `PATH` (e.g. `export PATH=$PATH:/usr/
 
 ## Usage
 
-Klar process returns if `0` if the number of detected high severity vulnerabilities in an image is less than or equal to a threshold (see below) and `1` if an error ahs prevented the image from being analyzed. Otherwise it returns `2`, indicating vulnerabilities were found.
+Klar process returns if `0` if the number of detected high severity vulnerabilities in an image is less than or equal to a threshold (see below) and `1` if there were more. It will return `2` if an error has prevented the image from being analyzed.
 
 Klar can be configured via the following environment variables:
 
@@ -32,7 +32,7 @@ Klar can be configured via the following environment variables:
 will be outputted. Supported levels are `Unknown`, `Negligible`, `Low`, `Medium`, `High`, `Critical`, `Defcon1`.
 Default is `Unknown`.
 
-* `CLAIR_THRESHOLD` - how many outputted vulnerabilities Klar can tolerate before returning `2`. Default is `0`.
+* `CLAIR_THRESHOLD` - how many outputted vulnerabilities Klar can tolerate before returning `1`. Default is `0`.
 
 * `CLAIR_TIMEOUT` - timeout in minutes before Klar cancels the image scanning. Default is `1`
 

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ v.FeatureVersion, v.FixedBy, v.Description, v.Link)
 	}
 
 	if vsNumber > conf.Threshold {
-		os.Exit(1)
+		os.Exit(2)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var store = make(map[string][]*clair.Vulnerability)
 func main() {
 	fail := func(format string, a ...interface{}) {
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("%s\n", format), a...)
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	if len(os.Args) != 2 {
@@ -137,7 +137,7 @@ v.FeatureVersion, v.FixedBy, v.Description, v.Link)
 	}
 
 	if vsNumber > conf.Threshold {
-		os.Exit(2)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Also updated the README to reflect this change. This should *not* break any automated tools that run klar and check for non-zero exit status. It will break tools that specifically check for an exit status of `1`.