### PR TITLE
Be able to fail if high severity CVES are found than the one specified in clair_output

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 
 	groupBySeverity(vs)
 	vsNumber := 0
+        higherSeverity := false        
 
 	if conf.JSONOutput {
 		iteratePriorities(conf.ClairOutput, func(sev string) {
@@ -131,6 +132,10 @@ v.FeatureVersion, v.FixedBy, v.Description, v.Link)
 				} else {
 					vsNumber++
 				}
+                               
+                                if (conf.ClairOutput !=  v.Severity) {
+                                    higherSeverity = true        
+                                }
 			}
 		})
 
@@ -139,6 +144,10 @@ v.FeatureVersion, v.FixedBy, v.Description, v.Link)
 	if vsNumber > conf.Threshold {
 		os.Exit(1)
 	}
+
+        if higherSeverity {
+           os.Exit(1)
+        } 
 }
 
 func iteratePriorities(output string, f func(sev string)) {


### PR DESCRIPTION
As it stands now clair will only fail if number of cves found are greater than threshold, but there is also clairout that shows the CVEs we are interested in.

But we wanted to have combination of these two. say we have 4 high ones and 1 critical one, (total 5)

if we have set the threshold limit to be 6 then clairout to be hight, we were under the impression that pass up to 6 high prio cvsm but if any criticals are obeserved we dont want to pass that. 

So we make sure that if any CVEs are observed beyond specified in clairout  then the pipeline will fail , no matter the threshold is met or not. If higer prio cves is not seen then threshold would still act to fail or move the pipeline forward