### PR TITLE
Fix build that has broken from a protobuf update

### DIFF
--- a/clair/clair_test.go
+++ b/clair/clair_test.go
@@ -128,7 +128,7 @@ func (s *gServer) PostAncestry(ctx context.Context, in *clairpb.PostAncestryRequ
 
 func (s *gServer) GetAncestry(ctx context.Context, in *clairpb.GetAncestryRequest) (*clairpb.GetAncestryResponse, error) {
 	return &clairpb.GetAncestryResponse{
-		Ancestry: &clairpb.Ancestry{
+		Ancestry: &clairpb.GetAncestryResponse_Ancestry{
 			Name: in.GetAncestryName(),
 			Features: []*clairpb.Feature{
 				{

--- a/vendor/github.com/coreos/clair/api/v3/clairpb/convert.go
+++ b/vendor/github.com/coreos/clair/api/v3/clairpb/convert.go
@@ -134,7 +134,7 @@ func AncestryFromDatabaseModel(dbAncestry database.Ancestry) *GetAncestryRespons
 }
 
 // LayerFromDatabaseModel converts database layer to api layer.
-func LayerFromDatabaseModel(dbLayer database.Layer) *Layer {
+func LayerFromDatabaseModel(dbLayer database.AncestryLayer) *Layer {
 	layer := Layer{Hash: dbLayer.Hash}
 	return &layer
 }


### PR DESCRIPTION
The database.Ancestry protobuf has changed format and now contains a database.AncestryLayer instead of a database.Layer.