### PR TITLE
Feature/support manifest list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ need to be booted with `-insecure-tls` for this to work.
 
 * `DOCKER_TIMEOUT` - timeout in minutes when trying to fetch layers from a docker registry
 
+* `DOCKER_PLATFORM_OS` - The operating system of the Docker image. Default is `linux`. This only needs to be set if the image specified references a Docker ManifestList instead of a usual manifest.
+
+* `DOCKER_PLATFORM_ARCH` - The architecture the Docker image is optimized for. Default is `amd64`. This only needs to be set if the image specified references a Docker ManifestList instead of a usual manifest.
+
 * `REGISTRY_INSECURE` - Allow Klar to access insecure registries (HTTP only). Default is `false`.
 
 * `JSON_OUTPUT` - Output JSON, not plain text. Default is `false`.

--- a/klar.go
+++ b/klar.go
@@ -28,21 +28,23 @@ type vulnerabilitiesWhitelist struct {
 }
 
 const (
-	optionClairOutput      = "CLAIR_OUTPUT"
-	optionClairAddress     = "CLAIR_ADDR"
-	optionKlarTrace        = "KLAR_TRACE"
-	optionClairThreshold   = "CLAIR_THRESHOLD"
-	optionClairTimeout     = "CLAIR_TIMEOUT"
-	optionDockerTimeout    = "DOCKER_TIMEOUT"
-	optionJSONOutput       = "JSON_OUTPUT" // deprecate?
-	optionFormatOutput     = "FORMAT_OUTPUT"
-	optionDockerUser       = "DOCKER_USER"
-	optionDockerPassword   = "DOCKER_PASSWORD"
-	optionDockerToken      = "DOCKER_TOKEN"
-	optionDockerInsecure   = "DOCKER_INSECURE"
-	optionRegistryInsecure = "REGISTRY_INSECURE"
-	optionWhiteListFile    = "WHITELIST_FILE"
-	optionIgnoreUnfixed    = "IGNORE_UNFIXED"
+	optionClairOutput        = "CLAIR_OUTPUT"
+	optionClairAddress       = "CLAIR_ADDR"
+	optionKlarTrace          = "KLAR_TRACE"
+	optionClairThreshold     = "CLAIR_THRESHOLD"
+	optionClairTimeout       = "CLAIR_TIMEOUT"
+	optionDockerTimeout      = "DOCKER_TIMEOUT"
+	optionJSONOutput         = "JSON_OUTPUT" // deprecate?
+	optionFormatOutput       = "FORMAT_OUTPUT"
+	optionDockerUser         = "DOCKER_USER"
+	optionDockerPassword     = "DOCKER_PASSWORD"
+	optionDockerToken        = "DOCKER_TOKEN"
+	optionDockerInsecure     = "DOCKER_INSECURE"
+	optionDockerPlatformOS   = "DOCKER_PLATFORM_OS"
+	optionDockerPlatformArch = "DOCKER_PLATFORM_ARCH"
+	optionRegistryInsecure   = "REGISTRY_INSECURE"
+	optionWhiteListFile      = "WHITELIST_FILE"
+	optionIgnoreUnfixed      = "IGNORE_UNFIXED"
 )
 
 var priorities = []string{"Unknown", "Negligible", "Low", "Medium", "High", "Critical", "Defcon1"}
@@ -175,6 +177,8 @@ func newConfig(args []string) (*config, error) {
 			InsecureTLS:      parseBoolOption(optionDockerInsecure),
 			InsecureRegistry: parseBoolOption(optionRegistryInsecure),
 			Timeout:          time.Duration(dockerTimeout) * time.Minute,
+			PlatformOS:       os.Getenv(optionDockerPlatformOS),
+			PlatformArch:     os.Getenv(optionDockerPlatformArch),
 		},
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	image, err := docker.NewImage(&conf.DockerConfig)
 	if err != nil {
-		fail("Can't parse qname: %s", err)
+		fail("Can't parse name: %s", err)
 	}
 
 	err = image.Pull()


### PR DESCRIPTION
* simplify Pull method of image type, one if case could be removed
* allow ManifestList content type
* add env vars to set preferred platform of image
* default is os=linux and arch=amd64
* if content type is manifestlist, the values from the env vars (or the
default) will be used to pick an image and pull it
* Note: the manifestlist has more (even more rarely used options). These
are not yet checked. If there is interest I can add them as well

This should fix #137 

This PR depends includes the changes from #145 and supersedes it