### PR TITLE
Fixed: Try to drain response body only if response exists

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -340,7 +340,9 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 	}
 	tResp, err := i.client.Do(req)
 	if err != nil {
-		io.Copy(ioutil.Discard, tResp.Body)
+		if tResp != nil {
+			io.Copy(ioutil.Discard, tResp.Body)
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
#### Description
While leveraging the klar repo, we noticed the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xb868c9]

goroutine 3890993 [running]:
github.com/optiopay/klar/docker.(*Image).requestToken(0xc00551bec0, 0xc01d6fcfc0, 0x0, 0x0, 0x0, 0x0)
    /tmp/build/ae5c2d4a/go/pkg/mod/github.com/optiopay/klar@v2.4.0+incompatible/docker/docker.go:295 +0x6e9
github.com/optiopay/klar/docker.(*Image).Pull(0xc00551bec0, 0x0, 0x0)
    /tmp/build/ae5c2d4a/go/pkg/mod/github.com/optiopay/klar@v2.4.0+incompatible/docker/docker.go:222 +0x1e1
go.aporeto.io/claire/internal/scanner.(*clairScanner).cacheImage(0xc0003ac540, 0xc009ec3e60, 0xf, 0xc04f6d3e40, 0xc0154aaa90)
```
The response is not checked if it is `nil` prior to trying to drain it. This will avoid the panic. : )