### PR TITLE
Fix broken build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.9-alpine as builder
 
 RUN apk --update add git;
 RUN go get -d github.com/optiopay/klar


### PR DESCRIPTION
Following on optiopay/klar#159

@annieweng points out we now need Go >= 1.9 to build klar.