### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.13-alpine as builder
 
 RUN apk --update add git;
 RUN go get -d github.com/optiopay/klar


### PR DESCRIPTION
Current build process doesn't work for me, and I'm getting the following error

```
$ docker build -t klar .
Sending build context to Docker daemon  24.69MB
Step 1/8 : FROM golang:1.8-alpine as builder
 ---> 4cb86d3661bf
Step 2/8 : RUN apk --update add git;
 ---> Using cache
 ---> 8bfa066d5be4
Step 3/8 : RUN go get -d github.com/optiopay/klar
 ---> Running in 71071a8f7805
package github.com/quay/clair/v3/pkg/commonerr: cannot find package "github.com/quay/clair/v3/pkg/commonerr" in any of:
	/usr/local/go/src/github.com/quay/clair/v3/pkg/commonerr (from $GOROOT)
	/go/src/github.com/quay/clair/v3/pkg/commonerr (from $GOPATH)
package github.com/quay/clair/v3/pkg/pagination: cannot find package "github.com/quay/clair/v3/pkg/pagination" in any of:
	/usr/local/go/src/github.com/quay/clair/v3/pkg/pagination (from $GOROOT)
	/go/src/github.com/quay/clair/v3/pkg/pagination (from $GOPATH)
package math/bits: unrecognized import path "math/bits" (import path does not begin with hostname)
The command '/bin/sh -c go get -d github.com/optiopay/klar' returned a non-zero code: 1
```
Updating the build image seems to solve the issue.