### PR TITLE
Use golang instead alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.8-alpine as builder
+FROM golang as builder
 
-RUN apk --update add git;
+#RUN apk --update add git;
 RUN go get -d github.com/optiopay/klar
 RUN go build ./src/github.com/optiopay/klar
 


### PR DESCRIPTION
Using alpine image docker build returns an error:
```
Step 3/8 : RUN go get -d github.com/optiopay/klar
 ---> Running in 6562fdf69543
package github.com/quay/clair/v3/pkg/commonerr: cannot find package "github.com/quay/clair/v3/pkg/commonerr" in any of:
	/usr/local/go/src/github.com/quay/clair/v3/pkg/commonerr (from $GOROOT)
	/go/src/github.com/quay/clair/v3/pkg/commonerr (from $GOPATH)
package github.com/quay/clair/v3/pkg/pagination: cannot find package "github.com/quay/clair/v3/pkg/pagination" in any of:
	/usr/local/go/src/github.com/quay/clair/v3/pkg/pagination (from $GOROOT)
	/go/src/github.com/quay/clair/v3/pkg/pagination (from $GOPATH)
```