### PR TITLE
#168 handle strange runes in auth url

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -329,7 +329,7 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 	if i.user != "" {
 		authURL = fmt.Sprintf("%s?service=%s&scope=%s&account=%s", realm, url.QueryEscape(service), scope, i.user)
 	} else {
-		authURL = fmt.Sprintf("%s?service=%s&scope=%s", realm, service, scope)
+		authURL = fmt.Sprintf("%s?service=%s&scope=%s", realm, url.QueryEscape(service), scope)
 	}
 	req, err := http.NewRequest("GET", authURL, nil)
 	if err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -324,13 +325,13 @@ func (i *Image) requestToken(resp *http.Response) (string, error) {
 		return "", fmt.Errorf("Can't parse Www-Authenticate: %s", authHeader)
 	}
 	realm, service, scope := parts[1], parts[2], parts[3]
-	var url string
+	var authURL string
 	if i.user != "" {
-		url = fmt.Sprintf("%s?service=%s&scope=%s&account=%s", realm, service, scope, i.user)
+		authURL = fmt.Sprintf("%s?service=%s&scope=%s&account=%s", realm, url.QueryEscape(service), scope, i.user)
 	} else {
-		url = fmt.Sprintf("%s?service=%s&scope=%s", realm, service, scope)
+		authURL = fmt.Sprintf("%s?service=%s&scope=%s", realm, service, scope)
 	}
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", authURL, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Can't create a request")
 		return "", err


### PR DESCRIPTION
In Issue #168 I mentioned that I always got a 400 error when trying to connect to a certain registry.  

After some digging I found out that the url to authenticate klar had an space which was not encode correctly by klar. Here is the code I used to make it work.

The url looked like this with "Docker Registry" in the service variable. The space triggered the error. 

"https://example.com/auth?service=Docker Registry&scope=repository:hello/world:pull&account=example-user"