### PR TITLE
Allow feature specific whitelists

### DIFF
--- a/klar.go
+++ b/klar.go
@@ -17,14 +17,16 @@ import (
 
 //Used to represent the structure of the whitelist YAML file
 type vulnerabilitiesWhitelistYAML struct {
-	General []string
-	Images  map[string][]string
+	General  []string
+	Images   map[string][]string
+	Features map[string][]string
 }
 
 //Map structure used for ease of searching for whitelisted vulnerabilites
 type vulnerabilitiesWhitelist struct {
-	General map[string]bool            //key: CVE and value: true
-	Images  map[string]map[string]bool //key: image name and value: [key: CVE and value: true]
+	General  map[string]bool            //key: CVE and value: true
+	Images   map[string]map[string]bool //key: image name and value: [key: CVE and value: true]
+	Features map[string]map[string]bool //key: feature name and value: [key: CVE and value: true]
 }
 
 const (
@@ -200,6 +202,7 @@ func parseWhitelistFile(whitelistFile string) (*vulnerabilitiesWhitelist, error)
 	//Initialize the whitelist maps
 	whitelist.General = make(map[string]bool)
 	whitelist.Images = make(map[string]map[string]bool)
+	whitelist.Features = make(map[string]map[string]bool)
 
 	//Populate the maps
 	for _, cve := range whitelistYAML.General {
@@ -210,6 +213,13 @@ func parseWhitelistFile(whitelistFile string) (*vulnerabilitiesWhitelist, error)
 		whitelist.Images[image] = make(map[string]bool)
 		for _, cve := range cveList {
 			whitelist.Images[image][cve] = true
+		}
+	}
+
+	for feature, cveList := range whitelistYAML.Features {
+		whitelist.Features[feature] = make(map[string]bool)
+		for _, cve := range cveList {
+			whitelist.Images[feature][cve] = true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -138,14 +138,20 @@ func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerabil
 	filteredVs := make([]*clair.Vulnerability, 0, len(vs))
 
 	for _, v := range vs {
-		if _, exists := generalWhitelist[v.Name]; !exists {
-			if _, exists := imageWhitelist[imageName][v.Name]; !exists {
-				if _, exists := featureWhitelist[v.FeatureName][v.Name]; !exists {
-					//vulnerability is not in the image whitelist, so add it to the list to return
-					filteredVs = append(filteredVs, v)
-				}
-			}
+		if _, exists := generalWhitelist[v.Name]; exists {
+			//vulnerability is whitelisted generally
+			continue
 		}
+		if _, exists := imageWhitelist[imageName][v.Name]; exists {
+			//vulnerability is whitelisted for this imageName
+			continue
+		}
+		if _, exists := featureWhitelist[v.FeatureName][v.Name]; exists {
+			//vulnerability is whitelisted for this feature name
+			continue
+		}
+		//vulnerability has not been whitelisted, so add it to the list to return
+		filteredVs = append(filteredVs, v)
 	}
 
 	return filteredVs

--- a/main.go
+++ b/main.go
@@ -133,14 +133,17 @@ func vulnsBy(sev string, store map[string][]*clair.Vulnerability) []*clair.Vulne
 func filterWhitelist(whitelist *vulnerabilitiesWhitelist, vs []*clair.Vulnerability, imageName string) []*clair.Vulnerability {
 	generalWhitelist := whitelist.General
 	imageWhitelist := whitelist.Images
+	featureWhitelist := whitelist.Features
 
 	filteredVs := make([]*clair.Vulnerability, 0, len(vs))
 
 	for _, v := range vs {
 		if _, exists := generalWhitelist[v.Name]; !exists {
 			if _, exists := imageWhitelist[imageName][v.Name]; !exists {
-				//vulnerability is not in the image whitelist, so add it to the list to return
-				filteredVs = append(filteredVs, v)
+				if _, exists := featureWhitelist[v.FeatureName][v.Name]; !exists {
+					//vulnerability is not in the image whitelist, so add it to the list to return
+					filteredVs = append(filteredVs, v)
+				}
 			}
 		}
 	}

--- a/whitelist-example.yaml
+++ b/whitelist-example.yaml
@@ -9,3 +9,6 @@ images:
   fluent/fluent-bit:
     - CVE-2017-14062
     - CVE-2018-6485
+features:
+  "db5.3":
+    - CVE-2019-8457


### PR DESCRIPTION
This change allows specific CVEs to be whitelisted when they affect a
specific feature. This is useful when a feature embeds a vulnerable
component, but uses it in a way that is not affected by the
vulnerability - and the user wants to ensure the CVE does not affect
other features (such as the OS Distribution's own package that
distributes the component).

See https://security-tracker.debian.org/tracker/CVE-2019-8457 for a
motivating example. Users may want to whitelist CVE-2019-8457 in the
context of the db5.3 package, but still be confident that sqlite3 has
been patched.